### PR TITLE
fix: routing and listing trip cards

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -19,20 +19,30 @@ const routes: Routes = [
   { path: 'singin', component: RegisterComponent },
   { path: 'login', component: LoginComponent },
   { path: 'me', component: ProfileComponent },
-  { path: 'trips', component: ListTripsComponent, children: [
-    { path: ':id', component: DisplayTripComponent },
-    { path: 'manager/:id', component: ListManagerTripsComponent }
-  ]},
-  { path: 'applications', children: [
-    { path: 'trip/:id', component: ListTripApplicationsComponent },
-    { path: 'explorer/:id', component: ListExplorerApplicationsComponent },
-  ]},
+  {
+    path: 'trips',
+    children: [
+      { path: ':id', component: DisplayTripComponent },
+      { path: 'manager/:id', component: ListManagerTripsComponent },
+      { path: '', component: ListTripsComponent },
+    ],
+  },
+  {
+    path: 'applications',
+    children: [
+      { path: 'trip/:id', component: ListTripApplicationsComponent },
+      { path: 'explorer/:id', component: ListExplorerApplicationsComponent },
+    ],
+  },
   { path: 'favourites/explorer/:id', component: ListFavouritesComponent },
-  { path: 'sponsorships', children: [
-    { path: 'sponsor/:id', component: ListSponsorshipsComponent },
-    { path: ':id', component: DisplaySponsorshipComponent }
-  ]},
-  { path: '', redirectTo: '', pathMatch: 'full'},
+  {
+    path: 'sponsorships',
+    children: [
+      { path: 'sponsor/:id', component: ListSponsorshipsComponent },
+      { path: ':id', component: DisplaySponsorshipComponent },
+    ],
+  },
+  { path: '', redirectTo: '', pathMatch: 'full' },
   { path: '**', component: NotFoundComponent },
 ];
 

--- a/src/app/components/master/header/header.component.html
+++ b/src/app/components/master/header/header.component.html
@@ -5,15 +5,6 @@
     <a class="navbar-brand ps-2" routerLink="/">
       <img src="../../../../assets/images/logo.svg" width="40" height="40" />
     </a>
-    <form class="d-flex" role="search">
-      <input
-        class="form-control ms-5"
-        type="search"
-        placeholder="Search"
-        aria-label="Search"
-      />
-      <button class="btn btn-outline-success" type="submit">Search</button>
-    </form>
 
     <button
       class="navbar-toggler"
@@ -30,10 +21,19 @@
       <ul class="navbar-nav mb-2 mb-md-0">
         <div>
           <ul class="navbar-nav mb-2 mb-lg-0">
+            <form class="d-flex me-2" role="search">
+              <input
+                class="form-control"
+                type="search"
+                placeholder="Search"
+                aria-label="Search"
+              />
+              <button class="btn btn-outline-success" type="submit">
+                Search
+              </button>
+            </form>
             <li class="nav-item">
-              <a class="nav-link active" routerLink="/trips">
-                Trips
-              </a>
+              <a class="nav-link active" routerLink="/trips"> Trips </a>
             </li>
             <li class="nav-item" *ngIf="!currentActor">
               <a class="nav-link active" routerLink="/singin">
@@ -71,7 +71,9 @@
                   >
                 </li>
                 <li *ngIf="activeRole === 'explorer'">
-                  <a class="dropdown-item" routerLink="/applications/explorer/:id"
+                  <a
+                    class="dropdown-item"
+                    routerLink="/applications/explorer/:id"
                     >My Applications</a
                   >
                 </li>
@@ -81,7 +83,9 @@
                   >
                 </li>
                 <li *ngIf="activeRole === 'sponsor'">
-                  <a class="dropdown-item" routerLink="/sponsorships/sponsor/:id"
+                  <a
+                    class="dropdown-item"
+                    routerLink="/sponsorships/sponsor/:id"
                     >My Sponsorships</a
                   >
                 </li>

--- a/src/app/components/trip/display-trip/display-trip.component.ts
+++ b/src/app/components/trip/display-trip/display-trip.component.ts
@@ -1,15 +1,30 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Trip } from 'src/app/models/trip.model';
+import { TripService } from 'src/app/services/trip.service';
 
 @Component({
   selector: 'app-display-trip',
   templateUrl: './display-trip.component.html',
-  styleUrls: ['./display-trip.component.css']
+  styleUrls: ['./display-trip.component.css'],
 })
 export class DisplayTripComponent implements OnInit {
+  trip: Trip;
+  id: string;
 
-  constructor() { }
-
-  ngOnInit(): void {
+  constructor(
+    private tripService: TripService,
+    private router: Router,
+    private route: ActivatedRoute
+  ) {
+    this.id = '0';
+    this.trip = new Trip();
   }
 
+  ngOnInit(): void {
+    this.id = this.route.snapshot.params['id'];
+    this.tripService.getTrip(this.id).subscribe((trip) => {
+      this.trip = trip;
+    });
+  }
 }

--- a/src/app/components/trip/list-trips/list-trips.component.html
+++ b/src/app/components/trip/list-trips/list-trips.component.html
@@ -1,18 +1,24 @@
-
-<div *ngIf="trips && trips.length > 0" class="row .row-cols-3 row-cols-md-3 g-4 mt-2">
-    <div *ngFor="let trip of trips" class="card">
-        <div class="card-body">
+<div *ngIf="trips && trips.length > 0" class="row g-4 mt-2">
+  <div *ngFor="let trip of trips" class="col-12 col-md-6">
+    <div class="card" routerLink="/trips/{{ trip._id }}">
+      <div class="card-body row">
+        <div class="d-flex">
+          <div class="d-flex flex-column col-10">
             <h4 class="card-title">
-                {{ trip.title }}
+              {{ trip.title }}
             </h4>
-            <p class="card-text">
-                {{ trip.startDate | date : "dd/MM/yyyy" }} - {{ trip.endDate | date : "dd/MM/yyyy" }}
+            <small class="card-text">
+              {{ trip.startDate | date : "dd/MM/yyyy" }} -
+              {{ trip.endDate | date : "dd/MM/yyyy" }}
+            </small>
+          </div>
+          <div class="align-self-center col-2">
+            <p class="card-text text-center">
+              <span class="badge bg-primary"> {{ trip.price }} $ </span>
             </p>
-            <p class="card-text">
-                <span class="badge bg-primary">
-                    {{ trip.price }} $
-                </span>
-            </p>
+          </div>
         </div>
+      </div>
     </div>
+  </div>
 </div>

--- a/src/app/components/trip/list-trips/list-trips.component.ts
+++ b/src/app/components/trip/list-trips/list-trips.component.ts
@@ -1,27 +1,30 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Actor } from 'src/app/models/actor.model';
-import { Trip } from 'src/app/models/trip';
+import { Trip } from 'src/app/models/trip.model';
 import { AuthService } from 'src/app/services/auth.service';
 import { TripService } from 'src/app/services/trip.service';
 
 @Component({
   selector: 'app-list-trips',
   templateUrl: './list-trips.component.html',
-  styleUrls: ['./list-trips.component.css']
+  styleUrls: ['./list-trips.component.css'],
 })
 export class ListTripsComponent implements OnInit {
-
   trips: Trip[];
   actor: Actor;
 
-  constructor(private tripService: TripService, private router: Router, private authService: AuthService) { 
+  constructor(
+    private tripService: TripService,
+    private router: Router,
+    private authService: AuthService
+  ) {
     this.trips = [];
     this.actor = new Actor();
   }
 
   ngOnInit(): void {
-    this.tripService.getTrips().subscribe((data:any) => this.trips = data);
+    this.tripService.getTrips().subscribe((data: any) => (this.trips = data));
     this.actor = this.authService.getCurrentActor()!;
   }
 }

--- a/src/app/models/entity.model.ts
+++ b/src/app/models/entity.model.ts
@@ -1,14 +1,14 @@
 export class Entity {
-  private _id: string;
+  private __id: string;
   private _version: number;
 
   constructor() {
-    this._id = '0';
+    this.__id = '0';
     this._version = 0;
   }
 
-  public get id(): string {
-    return this._id;
+  public get _id(): string {
+    return this.__id;
   }
 
   public get version(): number {

--- a/src/app/models/trip.model.spec.ts
+++ b/src/app/models/trip.model.spec.ts
@@ -1,4 +1,4 @@
-import { Trip } from './trip';
+import { Trip } from './trip.model';
 
 describe('Trip', () => {
   it('should create an instance', () => {

--- a/src/app/models/trip.model.ts
+++ b/src/app/models/trip.model.ts
@@ -1,4 +1,6 @@
-export class Trip {
+import { Entity } from './entity.model';
+
+export class Trip extends Entity {
   private _ticker!: string;
   private _title!: string;
   private _description!: string;
@@ -10,10 +12,14 @@ export class Trip {
   private _status!: string;
   private _imageCollections?: Buffer[] | undefined;
 
+  constructor() {
+    super();
+  }
+
   public get ticker(): string {
     return this._ticker;
   }
-  
+
   public set ticker(value: string) {
     this._ticker = value;
   }
@@ -90,6 +96,3 @@ export class Trip {
     this._imageCollections = value;
   }
 }
-
-
-

--- a/src/app/services/trip.service.ts
+++ b/src/app/services/trip.service.ts
@@ -1,20 +1,23 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { environment } from 'src/environments/environment';
-import { Trip } from '../models/trip';
+import { Trip } from '../models/trip.model';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class TripService {
-
   private tripsUrl = environment.backendApiBaseURL + '/api/v1/trips';
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient) {}
 
   getTrips() {
     const url = `${this.tripsUrl}`;
     return this.http.get<Trip[]>(url);
   }
 
+  getTrip(id: string) {
+    const url = `${this.tripsUrl}/${id}`;
+    return this.http.get<Trip>(url);
+  }
 }


### PR DESCRIPTION
El routing estaba mal hecho. Ya he entendido cómo funciona.

Tampoco se extendía de Entity en el caso de Trip (además de que el fichero estaba mal nombrado). En Entity hay que declarar bien el nombre del id, si no no lo reconoce a partir de nuestro backend.

Se ha actualizado un poco la card de listado, que es enlazable al trip en cuestión, para el cual se ha creado el componente de display, sin implementar.